### PR TITLE
Fix build

### DIFF
--- a/androidApp/src/main/java/com/example/githubrepos/android/detail/RepoDetails.kt
+++ b/androidApp/src/main/java/com/example/githubrepos/android/detail/RepoDetails.kt
@@ -33,10 +33,10 @@ typealias RepoDetails = @Composable (
 @Composable
 fun RepoDetails(
     @Assisted navigateUp: () -> Unit,
-    stateMachine: GithubRepoDetailStateMachine
+    stateMachine: (String) -> GithubRepoDetailStateMachine
 ) {
 
-    val (state, dispatch) = stateMachine.rememberStateAndDispatch()
+    val (state, dispatch) = stateMachine("id").rememberStateAndDispatch()
 
     RepoDetails(
         state = state.value,


### PR DESCRIPTION
`GithubRepoDetailStateMachine` has an assisted injected argument, so we can’t ask for it as a dependency. We can only ask for a creator lambda that shouldl expect the necessary assisted argument.

If we simply ask for a `GithubRepoDetailStateMachine`, what would be the `id` used to create the instance? It’s an assisted argument, so we must pass it ourselves whenever we want a new instance. Another way to fix the build is to set a default value for the assisted `id` argument, though, then we’re able to ask for an instance without passing an `id` since the default value can be used instead.